### PR TITLE
feat(projects): display project type and keywords

### DIFF
--- a/components/projects.js
+++ b/components/projects.js
@@ -3,36 +3,62 @@ import markdown from '../utils/markdown.js'
 import Duration from './duration.js'
 import Link from './link.js'
 
-const formatRoles = arr => Intl.ListFormat
-  ? new Intl.ListFormat('en').format(arr)
-  : arr.join(', ')
+const formatRoles = arr =>
+  Intl.ListFormat ? new Intl.ListFormat('en').format(arr) : arr.join(', ')
 
 export default function Projects(projects = []) {
-  return projects.length > 0 && html`
-    <section id="projects">
-      <h3>Projects</h3>
-      <div class="stack">
-      ${projects.map(({ description, entity, highlights = [], name, startDate, endDate, roles = [], url }) => html`
-        <article>
-          <header>
-            <h4>${Link(url, name)}</h4>
-            <div class="meta">
-              <div>
-                ${roles.length > 0 && html`<strong>${formatRoles(roles)}</strong>`}
-                ${entity && html`at <strong>${entity}</strong>`}
-              </div>
-              <div>${Duration(startDate, endDate)}</div>
-            </div>
-          </header>
-          ${description && markdown(description)}
-          ${highlights.length > 0 && html`
-            <ul>
-              ${highlights.map(highlight => html`<li>${markdown(highlight)}</li>`)}
-            </ul>
-          `}
-        </article>
-      `)}
-      </div>
-    </section>
-  `
+  return (
+    projects.length > 0 &&
+    html`
+      <section id="projects">
+        <h3>Projects</h3>
+        <div class="stack">
+          ${projects.map(
+            ({
+              description,
+              entity,
+              type,
+              highlights = [],
+              keywords,
+              name,
+              startDate,
+              endDate,
+              roles = [],
+              url,
+            }) => html`
+              <article>
+                <header>
+                  <h4>${Link(url, name)}</h4>
+                  <div class="meta">
+                    <div>
+                      ${roles.length > 0 &&
+                      html`<strong>${formatRoles(roles)}</strong>`}
+                      ${entity && html`at <strong>${entity}</strong>`}
+                    </div>
+                    <div>${Duration(startDate, endDate)}</div>
+                    ${type && html`<div>${type}</div>`}
+                  </div>
+                </header>
+                ${description && markdown(description)}
+                ${keywords.length > 0 &&
+                html`
+                  <ul class="tag-list">
+                    ${keywords.map(keyword => html`<li>${keyword}</li>`)}
+                  </ul>
+                `}
+                ${highlights.length > 0 &&
+                html`
+                  <ul>
+                    ${highlights.map(
+                      highlight => html`<li>${markdown(highlight)}</li>`,
+                    )}
+                  </ul>
+                `}
+              </article>
+            `,
+          )}
+        </div>
+      </section>
+    `
+  )
 }

--- a/components/projects.js
+++ b/components/projects.js
@@ -3,62 +3,42 @@ import markdown from '../utils/markdown.js'
 import Duration from './duration.js'
 import Link from './link.js'
 
-const formatRoles = arr =>
-  Intl.ListFormat ? new Intl.ListFormat('en').format(arr) : arr.join(', ')
+const formatRoles = arr => Intl.ListFormat
+  ? new Intl.ListFormat('en').format(arr)
+  : arr.join(', ')
 
 export default function Projects(projects = []) {
-  return (
-    projects.length > 0 &&
-    html`
-      <section id="projects">
-        <h3>Projects</h3>
-        <div class="stack">
-          ${projects.map(
-            ({
-              description,
-              entity,
-              type,
-              highlights = [],
-              keywords,
-              name,
-              startDate,
-              endDate,
-              roles = [],
-              url,
-            }) => html`
-              <article>
-                <header>
-                  <h4>${Link(url, name)}</h4>
-                  <div class="meta">
-                    <div>
-                      ${roles.length > 0 &&
-                      html`<strong>${formatRoles(roles)}</strong>`}
-                      ${entity && html`at <strong>${entity}</strong>`}
-                    </div>
-                    <div>${Duration(startDate, endDate)}</div>
-                    ${type && html`<div>${type}</div>`}
-                  </div>
-                </header>
-                ${description && markdown(description)}
-                ${keywords.length > 0 &&
-                html`
-                  <ul class="tag-list">
-                    ${keywords.map(keyword => html`<li>${keyword}</li>`)}
-                  </ul>
-                `}
-                ${highlights.length > 0 &&
-                html`
-                  <ul>
-                    ${highlights.map(
-                      highlight => html`<li>${markdown(highlight)}</li>`,
-                    )}
-                  </ul>
-                `}
-              </article>
-            `,
-          )}
-        </div>
-      </section>
-    `
-  )
+  return projects.length > 0 && html`
+    <section id="projects">
+      <h3>Projects</h3>
+      <div class="stack">
+      ${projects.map(({ description, entity, highlights = [], keywords = [], name, startDate, endDate, roles = [], type, url }) => html`
+        <article>
+          <header>
+            <h4>${Link(url, name)}</h4>
+            <div class="meta">
+              <div>
+                ${roles.length > 0 && html`<strong>${formatRoles(roles)}</strong>`}
+                ${entity && html`at <strong>${entity}</strong>`}
+              </div>
+              <div>${Duration(startDate, endDate)}</div>
+              ${type && html`<div>${type}</div>`}
+            </div>
+          </header>
+          ${description && markdown(description)}
+          ${highlights.length > 0 && html`
+            <ul>
+              ${highlights.map(highlight => html`<li>${markdown(highlight)}</li>`)}
+            </ul>
+          `}
+          ${keywords.length > 0 && html`
+            <ul class="tag-list">
+              ${keywords.map(keyword => html`<li>${keyword}</li>`)}
+            </ul>
+          `}
+        </article>
+      `)}
+      </div>
+    </section>
+  `
 }

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -149,38 +149,38 @@ exports[`renders a resume 1`] = `
     </section>
   
         
-      <section id=\\"projects\\">
-        <h3>Projects</h3>
-        <div class=\\"stack\\">
+    <section id=\\"projects\\">
+      <h3>Projects</h3>
+      <div class=\\"stack\\">
+      
+        <article>
+          <header>
+            <h4><a href=\\"missdirection.example.com\\">Miss Direction</a></h4>
+            <div class=\\"meta\\">
+              <div>
+                <strong>Team lead and Designer</strong>
+                at <strong>Smoogle</strong>
+              </div>
+              <div><time datetime=\\"2016-08-24\\">Aug 2016</time> – <time datetime=\\"2016-08-24\\">Aug 2016</time></div>
+              <div>application</div>
+            </div>
+          </header>
+          <p>A mapping engine that misguides you</p>
           
-              <article>
-                <header>
-                  <h4><a href=\\"missdirection.example.com\\">Miss Direction</a></h4>
-                  <div class=\\"meta\\">
-                    <div>
-                      <strong>Team lead and Designer</strong>
-                      at <strong>Smoogle</strong>
-                    </div>
-                    <div><time datetime=\\"2016-08-24\\">Aug 2016</time> – <time datetime=\\"2016-08-24\\">Aug 2016</time></div>
-                    <div>application</div>
-                  </div>
-                </header>
-                <p>A mapping engine that misguides you</p>
-                
-                  <ul class=\\"tag-list\\">
-                    <li>GoogleMaps</li><li>Chrome Extension</li><li>Javascript</li>
-                  </ul>
-                
-                
-                  <ul>
-                    <li><p>Won award at AIHacks 2016</p></li><li><p>Built by all women team of newbie programmers</p></li><li><p>Using modern technologies such as GoogleMaps, Chrome Extension and Javascript</p></li>
-                  </ul>
-                
-              </article>
-            
-        </div>
-      </section>
-    
+            <ul>
+              <li><p>Won award at AIHacks 2016</p></li><li><p>Built by all women team of newbie programmers</p></li><li><p>Using modern technologies such as GoogleMaps, Chrome Extension and Javascript</p></li>
+            </ul>
+          
+          
+            <ul class=\\"tag-list\\">
+              <li>GoogleMaps</li><li>Chrome Extension</li><li>Javascript</li>
+            </ul>
+          
+        </article>
+      
+      </div>
+    </section>
+  
         
     <section id=\\"awards\\">
       <h3>Awards</h3>

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -149,32 +149,38 @@ exports[`renders a resume 1`] = `
     </section>
   
         
-    <section id=\\"projects\\">
-      <h3>Projects</h3>
-      <div class=\\"stack\\">
-      
-        <article>
-          <header>
-            <h4><a href=\\"missdirection.example.com\\">Miss Direction</a></h4>
-            <div class=\\"meta\\">
-              <div>
-                <strong>Team lead and Designer</strong>
-                at <strong>Smoogle</strong>
-              </div>
-              <div><time datetime=\\"2016-08-24\\">Aug 2016</time> – <time datetime=\\"2016-08-24\\">Aug 2016</time></div>
-            </div>
-          </header>
-          <p>A mapping engine that misguides you</p>
+      <section id=\\"projects\\">
+        <h3>Projects</h3>
+        <div class=\\"stack\\">
           
-            <ul>
-              <li><p>Won award at AIHacks 2016</p></li><li><p>Built by all women team of newbie programmers</p></li><li><p>Using modern technologies such as GoogleMaps, Chrome Extension and Javascript</p></li>
-            </ul>
-          
-        </article>
-      
-      </div>
-    </section>
-  
+              <article>
+                <header>
+                  <h4><a href=\\"missdirection.example.com\\">Miss Direction</a></h4>
+                  <div class=\\"meta\\">
+                    <div>
+                      <strong>Team lead and Designer</strong>
+                      at <strong>Smoogle</strong>
+                    </div>
+                    <div><time datetime=\\"2016-08-24\\">Aug 2016</time> – <time datetime=\\"2016-08-24\\">Aug 2016</time></div>
+                    <div>application</div>
+                  </div>
+                </header>
+                <p>A mapping engine that misguides you</p>
+                
+                  <ul class=\\"tag-list\\">
+                    <li>GoogleMaps</li><li>Chrome Extension</li><li>Javascript</li>
+                  </ul>
+                
+                
+                  <ul>
+                    <li><p>Won award at AIHacks 2016</p></li><li><p>Built by all women team of newbie programmers</p></li><li><p>Using modern technologies such as GoogleMaps, Chrome Extension and Javascript</p></li>
+                  </ul>
+                
+              </article>
+            
+        </div>
+      </section>
+    
         
     <section id=\\"awards\\">
       <h3>Awards</h3>


### PR DESCRIPTION
Motivation
----------
I'm using `keywords` extensively in my CV. It turns out that [resume-schema](https://github.com/jsonresume/resume-schema/blob/master/schema.json) specifies these for `projects` too. I would expect the reference implementation here to do something with it.

How to test
-----------
1. `npm run test`
2. Test pass

*or*

1. `npm run build:demo`
2. `http-server public`
3. Visit [localhost:8080](http://localhost:8080/)
4. See keywords `GoogleMaps`, `Chrome Extension`, `Javascript` and type `application`

![image](https://github.com/rbardini/jsonresume-theme-even/assets/2110676/0f1e8f21-a570-4b4b-a090-85c0d39b9816)
