### PR TITLE
Add ability to change ordering of sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ Here's an example using the default theme colors:
 }
 ```
 
-### Order
+### Sections
 
-You can override the default order of sections via the `.meta.order` resume field.
-You can put however many sections you wish, ordered from top to bottom.
-The available sections you may order are provided below:
+You can override what sections are displayed, and in what order, via the `.meta.sections` resume field.
+
+Here's an example with all available sections in their default order:
 
 ```json
 {
   "meta": {
-    "order": [
+    "sections": [
       "work",
       "volunteer",
       "education",

--- a/README.md
+++ b/README.md
@@ -73,3 +73,31 @@ Here's an example using the default theme colors:
   }
 }
 ```
+
+### Order
+
+You can override the default order of sections via the `.meta.order` resume field.
+You can put however many sections you wish, ordered from top to bottom.
+The available sections you may order are provided below:
+
+```json
+{
+  "meta": {
+    "order": [
+      "work",
+      "volunteer",
+      "education",
+      "projects",
+      "awards",
+      "certificates",
+      "publications",
+      "skills",
+      "languages",
+      "interests",
+      "references"
+    ]
+  }
+}
+```
+
+Any sections not in the above list are not registered and won't be displayed in the final render.

--- a/components/body.js
+++ b/components/body.js
@@ -1,0 +1,47 @@
+import Work from "./work.js";
+import Volunteer from "./volunteer.js";
+import Education from "./education.js";
+import Projects from "./projects.js";
+import Awards from "./awards.js";
+import Certificates from "./certificates.js";
+import Publications from "./publications.js";
+import Skills from "./skills.js";
+import Languages from "./languages.js";
+import Interests from "./interests.js";
+import References from "./references.js";
+import html from "../utils/html.js";
+
+export default function Body(resume) {
+    let resumeOrder = resume.meta.order
+    if (resumeOrder === undefined) {
+        resumeOrder = [
+            'work',
+            'volunteer',
+            'education',
+            'projects',
+            'awards',
+            'certificates',
+            'publications',
+            'skills',
+            'languages',
+            'interests',
+            'references',
+        ]
+    }
+
+    const orderComponentMap = {
+        work: Work(resume.work),
+        volunteer: Volunteer(resume.volunteer),
+        education: Education(resume.education),
+        projects: Projects(resume.projects),
+        awards: Awards(resume.awards),
+        certificates: Certificates(resume.certificates),
+        publications: Publications(resume.publications),
+        skills: Skills(resume.skills),
+        languages: Languages(resume.languages),
+        interests: Interests(resume.interests),
+        references: References(resume.references),
+    }
+
+    return html`${resumeOrder.map(section => html`${orderComponentMap[section]}`)}`;
+}

--- a/components/body.js
+++ b/components/body.js
@@ -11,37 +11,21 @@ import Interests from "./interests.js";
 import References from "./references.js";
 import html from "../utils/html.js";
 
-export default function Body(resume) {
-    let resumeOrder = resume.meta.order
-    if (resumeOrder === undefined) {
-        resumeOrder = [
-            'work',
-            'volunteer',
-            'education',
-            'projects',
-            'awards',
-            'certificates',
-            'publications',
-            'skills',
-            'languages',
-            'interests',
-            'references',
-        ]
-    }
+const sectionComponentMap = {
+  work: (resume) => Work(resume.work),
+  volunteer: (resume) => Volunteer(resume.volunteer),
+  education: (resume) => Education(resume.education),
+  projects: (resume) => Projects(resume.projects),
+  awards: (resume) => Awards(resume.awards),
+  certificates: (resume) => Certificates(resume.certificates),
+  publications: (resume) => Publications(resume.publications),
+  skills: (resume) => Skills(resume.skills),
+  languages: (resume) => Languages(resume.languages),
+  interests: (resume) => Interests(resume.interests),
+  references: (resume) => References(resume.references),
+}
 
-    const orderComponentMap = {
-        work: Work(resume.work),
-        volunteer: Volunteer(resume.volunteer),
-        education: Education(resume.education),
-        projects: Projects(resume.projects),
-        awards: Awards(resume.awards),
-        certificates: Certificates(resume.certificates),
-        publications: Publications(resume.publications),
-        skills: Skills(resume.skills),
-        languages: Languages(resume.languages),
-        interests: Interests(resume.interests),
-        references: References(resume.references),
-    }
-
-    return html`${resumeOrder.map(section => html`${orderComponentMap[section]}`)}`;
+export default function Sections(resume) {
+  const sections = resume.meta?.sections || Object.keys(sectionComponentMap)
+  return html`${sections.map(section => sectionComponentMap[section]?.(resume))}`
 }

--- a/resume.js
+++ b/resume.js
@@ -1,8 +1,8 @@
 import Header from './components/header.js'
 import Meta from './components/meta.js'
+import Sections from './components/sections.js'
 import colors from './utils/colors.js'
 import html from './utils/html.js'
-import Body from "./components/body.js";
 
 export default function Resume(resume, css) {
   return html`<!DOCTYPE html>

--- a/resume.js
+++ b/resume.js
@@ -15,9 +15,9 @@ import colors from './utils/colors.js'
 import html from './utils/html.js'
 
 export default function Resume(resume, css) {
-  let order = resume.meta.order
-  if (order === undefined) {
-    order = [
+  let resumeOrder = resume.meta.order
+  if (resumeOrder === undefined) {
+    resumeOrder = [
       'work',
       'volunteer',
       'education',
@@ -46,23 +46,18 @@ export default function Resume(resume, css) {
     references: References(resume.references),
   }
 
-  return html`<!doctype html>
+  return html`<!DOCTYPE html>
     <html lang="en" style="${colors(resume.meta)}">
       <head>
-        <meta charset="utf-8" />
+        <meta charset="utf-8">
         ${Meta(resume.basics)}
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link
-          rel="stylesheet"
-          href="https://fonts.googleapis.com/css?family=Lato:400,700&display=swap"
-        />
-        <style>
-          ${css}
-        </style>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700&display=swap">
+        <style>${css}</style>
       </head>
       <body>
         ${Header(resume.basics)}
-        ${order.map(section => html`${orderComponentMap[section]}`)}
+        ${resumeOrder.map(section => html`${orderComponentMap[section]}`)}
       </body>
     </html>`
 }

--- a/resume.js
+++ b/resume.js
@@ -15,28 +15,54 @@ import colors from './utils/colors.js'
 import html from './utils/html.js'
 
 export default function Resume(resume, css) {
-  return html`<!DOCTYPE html>
+  let order = resume.meta.order
+  if (order === undefined) {
+    order = [
+      'work',
+      'volunteer',
+      'education',
+      'projects',
+      'awards',
+      'certificates',
+      'publications',
+      'skills',
+      'languages',
+      'interests',
+      'references',
+    ]
+  }
+
+  const orderComponentMap = {
+    work: Work(resume.work),
+    volunteer: Volunteer(resume.volunteer),
+    education: Education(resume.education),
+    projects: Projects(resume.projects),
+    awards: Awards(resume.awards),
+    certificates: Certificates(resume.certificates),
+    publications: Publications(resume.publications),
+    skills: Skills(resume.skills),
+    languages: Languages(resume.languages),
+    interests: Interests(resume.interests),
+    references: References(resume.references),
+  }
+
+  return html`<!doctype html>
     <html lang="en" style="${colors(resume.meta)}">
       <head>
-        <meta charset="utf-8">
+        <meta charset="utf-8" />
         ${Meta(resume.basics)}
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700&display=swap">
-        <style>${css}</style>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css?family=Lato:400,700&display=swap"
+        />
+        <style>
+          ${css}
+        </style>
       </head>
       <body>
         ${Header(resume.basics)}
-        ${Work(resume.work)}
-        ${Volunteer(resume.volunteer)}
-        ${Education(resume.education)}
-        ${Projects(resume.projects)}
-        ${Awards(resume.awards)}
-        ${Certificates(resume.certificates)}
-        ${Publications(resume.publications)}
-        ${Skills(resume.skills)}
-        ${Languages(resume.languages)}
-        ${Interests(resume.interests)}
-        ${References(resume.references)}
+        ${order.map(section => html`${orderComponentMap[section]}`)}
       </body>
     </html>`
 }

--- a/resume.js
+++ b/resume.js
@@ -1,51 +1,10 @@
-import Awards from './components/awards.js'
-import Certificates from './components/certificates.js'
-import Education from './components/education.js'
 import Header from './components/header.js'
-import Interests from './components/interests.js'
-import Languages from './components/languages.js'
 import Meta from './components/meta.js'
-import Projects from './components/projects.js'
-import Publications from './components/publications.js'
-import References from './components/references.js'
-import Skills from './components/skills.js'
-import Volunteer from './components/volunteer.js'
-import Work from './components/work.js'
 import colors from './utils/colors.js'
 import html from './utils/html.js'
+import Body from "./components/body.js";
 
 export default function Resume(resume, css) {
-  let resumeOrder = resume.meta.order
-  if (resumeOrder === undefined) {
-    resumeOrder = [
-      'work',
-      'volunteer',
-      'education',
-      'projects',
-      'awards',
-      'certificates',
-      'publications',
-      'skills',
-      'languages',
-      'interests',
-      'references',
-    ]
-  }
-
-  const orderComponentMap = {
-    work: Work(resume.work),
-    volunteer: Volunteer(resume.volunteer),
-    education: Education(resume.education),
-    projects: Projects(resume.projects),
-    awards: Awards(resume.awards),
-    certificates: Certificates(resume.certificates),
-    publications: Publications(resume.publications),
-    skills: Skills(resume.skills),
-    languages: Languages(resume.languages),
-    interests: Interests(resume.interests),
-    references: References(resume.references),
-  }
-
   return html`<!DOCTYPE html>
     <html lang="en" style="${colors(resume.meta)}">
       <head>
@@ -57,7 +16,7 @@ export default function Resume(resume, css) {
       </head>
       <body>
         ${Header(resume.basics)}
-        ${resumeOrder.map(section => html`${orderComponentMap[section]}`)}
+        ${Body(resume)}
       </body>
     </html>`
 }

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -99,7 +99,6 @@ exports[`renders a resume 1`] = `
       </div>
     </section>
   
-        
     <section id=\\"volunteer\\">
       <h3>Volunteer</h3>
       <div class=\\"stack\\">
@@ -123,7 +122,6 @@ exports[`renders a resume 1`] = `
       </div>
     </section>
   
-        
     <section id=\\"education\\">
       <h3>Education</h3>
       <div class=\\"stack\\">
@@ -148,7 +146,6 @@ exports[`renders a resume 1`] = `
       </div>
     </section>
   
-        
     <section id=\\"projects\\">
       <h3>Projects</h3>
       <div class=\\"stack\\">
@@ -181,7 +178,6 @@ exports[`renders a resume 1`] = `
       </div>
     </section>
   
-        
     <section id=\\"awards\\">
       <h3>Awards</h3>
       <div class=\\"stack\\">
@@ -204,8 +200,6 @@ exports[`renders a resume 1`] = `
       </div>
     </section>
   
-        
-        
     <section id=\\"publications\\">
       <h3>Publications</h3>
       <div class=\\"stack\\">
@@ -228,7 +222,6 @@ exports[`renders a resume 1`] = `
       </div>
     </section>
   
-        
     <section id=\\"skills\\">
       <h3>Skills</h3>
       <div class=\\"grid-list\\">
@@ -254,7 +247,6 @@ exports[`renders a resume 1`] = `
       </div>
     </section>
   
-        
     <section id=\\"languages\\">
       <h3>Languages</h3>
       <div class=\\"grid-list\\">
@@ -267,7 +259,6 @@ exports[`renders a resume 1`] = `
       </div>
     </section>
   
-        
     <section id=\\"interests\\">
       <h3>Interests</h3>
       <div class=\\"grid-list\\">
@@ -284,7 +275,6 @@ exports[`renders a resume 1`] = `
       </div>
     </section>
   
-        
     <section id=\\"references\\">
       <h3>References</h3>
       <div class=\\"stack\\">


### PR DESCRIPTION
**TL;DR** You can define a custom ordering of sections within the `meta.order` field of your `resume.json` like below:
```json
{
  "meta": {
      "theme": "even",
      "colors": {
        "background": ["#ffffff", "#191e23"],
        "dimmed": ["#f3f4f5", "#23282d"],
        "primary": ["#191e23", "#fbfbfc"],
        "secondary": ["#6c7781", "#ccd0d4"],
        "accent": ["#0073aa", "#00a0d2"]
      },
      "order": [
        "work",
        "volunteer",
        "publications",
        "education",
        "projects",
        "awards",
        "certificates",
        "skills",
        "languages",
        "interests",
        "references"
      ]
    }
}
```

My reasoning for this change that I didn't like the default ordering of the theme, I wanted to make some sections appear first before others. Thanks to the modularity of this theme, it was a relatively simple fix. This fix shouldn't affect any current users, as if no order supplied, the default one provided by the maintainers will be used.

This fix also means that you can choose to omit certain sections altogether or (if you want) display the same section again and again.

Because of a little weirdness in newlines generating, I had to provide a new snapshot file, but you can see that the changes are minimal and only apply to a couple of newlines.

I have tested these changes to a success on my local resume, the sample resume, as well as if the order has an invalid/misspelt selection. By default, if the order contains a section that doesn't exist, it simply ignores it. 

Lastly, I have modularized the code so that it fits the overall code-style of this repository.

Please let me know if you have any other questions, and hats off to the team for making these edits quite simple.