### PR TITLE
docs(readme): add theme reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ Inspired by [jsonresume-theme-flat](https://github.com/erming/jsonresume-theme-f
 npm install jsonresume-theme-even
 ```
 
+Specify the theme in your `resume.json`:
+
+```json
+{
+  "meta": {
+    "theme": "jsonresume-theme-even"
+    }
+}
+```
+
 ## Usage
 
 ### With resume-cli


### PR DESCRIPTION
I am new to `resume-cli` and `resumed` and it took me some time to figure out that I have to specify the full theme package name in `meta.theme`.

I ran `resumed render` and it told me:

> Could not load theme even. Is it installed?

So I installed `jsonresume-theme-even` and put `even` in `meta.theme` but it was still failing. That's why I think it is important to mention that the full package name has to be specified.