### PR TITLE
Add support for Font Awesome icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,17 @@ Here's an example using the default theme colors:
   }
 }
 ```
+
+### Icons
+
+By default, [Feather icons](https://feathericons.com/) are used for the profiles. You can also use [Font Awesome icons](https://fontawesome.com/) by setting the `.meta.themeOptions.icons` resume field to "fontawesome":
+
+```json
+{
+  "meta": {
+    "themeOptions": {
+      "icons": "fontawesome"
+    }
+  }
+}
+```

--- a/assets/page.css
+++ b/assets/page.css
@@ -160,6 +160,11 @@ svg {
   vertical-align: text-bottom;
 }
 
+.icon-fa {
+  margin-right: 0.2em;
+  vertical-align: text-bottom;
+}
+
 .masthead {
   background: var(--color-dimmed);
   display: inherit;

--- a/components/header.js
+++ b/components/header.js
@@ -12,9 +12,10 @@ const formatCountry = countryCode =>
 
 /**
  * @param {import('../schema.d.ts').ResumeSchema['basics']} basics
+ * @param {{ iconSet?: 'feather' | 'fontawesome' }} [options]
  * @returns {string}
  */
-export default function Header(basics = {}) {
+export default function Header(basics = {}, { iconSet = 'feather' } = {}) {
   const { email, image, label, location, name, phone, profiles = [], summary, url } = basics
 
   return html`
@@ -26,28 +27,29 @@ export default function Header(basics = {}) {
         ${location?.city &&
         html`
           <li>
-            ${Icon('map-pin')} ${location.city}${location.countryCode && html`, ${formatCountry(location.countryCode)}`}
+            ${Icon('map-pin', undefined, iconSet)}
+            ${location.city}${location.countryCode && html`, ${formatCountry(location.countryCode)}`}
           </li>
         `}
         ${email &&
         html`
           <li>
-            ${Icon('mail')}
+            ${Icon('mail', undefined, iconSet)}
             <a href="mailto:${email}">${email}</a>
           </li>
         `}
         ${phone &&
         html`
           <li>
-            ${Icon('phone')}
+            ${Icon('phone', undefined, iconSet)}
             <a href="tel:${phone.replace(/\s/g, '')}">${phone}</a>
           </li>
         `}
-        ${url && html`<li>${Icon('link')} ${Link(url)}</li>`}
+        ${url && html`<li>${Icon('link', undefined, iconSet)} ${Link(url)}</li>`}
         ${profiles.map(
           ({ network, url, username }) => html`
             <li>
-              ${network && Icon(network, 'user')} ${Link(url, username)}
+              ${network && Icon(network, 'user', iconSet)} ${Link(url, username)}
               ${network && html`<span class="network">(${network})</span>`}
             </li>
           `,

--- a/components/icon.js
+++ b/components/icon.js
@@ -1,15 +1,39 @@
+import { findIconDefinition, icon, library } from '@fortawesome/fontawesome-svg-core'
+import { fab } from '@fortawesome/free-brands-svg-icons'
+import { far } from '@fortawesome/free-regular-svg-icons'
+import { fas } from '@fortawesome/free-solid-svg-icons'
 import feather from 'feather-icons'
+
+library.add(fas, far, fab)
 
 /** @typedef {import('feather-icons').FeatherIconNames} FeatherIconNames */
 
 /**
  * @param {string} name
  * @param {string} [fallback]
+ * @param {'feather' | 'fontawesome'} [iconSet]
  * @returns {string | undefined}
  */
-export default function Icon(name, fallback) {
-  const icon =
-    feather.icons[/** @type {FeatherIconNames} */ (name.toLowerCase())] ||
+export default function Icon(name, fallback, iconSet = 'feather') {
+  const key = name?.toLowerCase?.()
+
+  if (iconSet === 'fontawesome') {
+    // Try to find the icon in different FontAwesome sets
+    const faIconR = findIconDefinition({ prefix: 'far', iconName: /** @type {any} */ (key) })
+    const faIconS = findIconDefinition({ prefix: 'fas', iconName: /** @type {any} */ (key) })
+    const faIconB = findIconDefinition({ prefix: 'fab', iconName: /** @type {any} */ (key) })
+    const faIconDef = faIconS || faIconR || faIconB
+    if (faIconDef) {
+      const faIcon = icon(faIconDef, {
+        classes: ['icon-fa', 'fa-fw'],
+        attributes: { width: 16, height: 16 },
+      })
+      return faIcon.html[0]
+    }
+  }
+
+  const featherIcon =
+    (key && feather.icons[/** @type {FeatherIconNames} */ (key)]) ||
     (fallback && feather.icons[/** @type {FeatherIconNames} */ (fallback.toLowerCase())])
-  return icon?.toSvg({ width: 16, height: 16 })
+  return featherIcon?.toSvg({ width: 16, height: 16 })
 }

--- a/components/resume.js
+++ b/components/resume.js
@@ -22,6 +22,7 @@ import Work from './work.js'
  * @returns
  */
 export default function Resume(resume, { css, js } = {}) {
+  const iconSet = resume.meta?.themeOptions?.icons?.toLowerCase?.() === 'fontawesome' ? 'fontawesome' : 'feather'
   return html`<!doctype html>
     <html lang="en" style="${colors(resume.meta)}">
       <head>
@@ -39,10 +40,10 @@ export default function Resume(resume, { css, js } = {}) {
         </script>`}
       </head>
       <body>
-        ${Header(resume.basics)} ${Work(resume.work)} ${Volunteer(resume.volunteer)} ${Education(resume.education)}
-        ${Projects(resume.projects)} ${Awards(resume.awards)} ${Certificates(resume.certificates)}
-        ${Publications(resume.publications)} ${Skills(resume.skills)} ${Languages(resume.languages)}
-        ${Interests(resume.interests)} ${References(resume.references)}
+        ${Header(resume.basics, { iconSet })} ${Work(resume.work)} ${Volunteer(resume.volunteer)}
+        ${Education(resume.education)} ${Projects(resume.projects)} ${Awards(resume.awards)}
+        ${Certificates(resume.certificates)} ${Publications(resume.publications)} ${Skills(resume.skills)}
+        ${Languages(resume.languages)} ${Interests(resume.interests)} ${References(resume.references)}
       </body>
     </html>`
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "0.26.1",
       "license": "MIT",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^7.1.0",
+        "@fortawesome/free-brands-svg-icons": "^7.1.0",
+        "@fortawesome/free-regular-svg-icons": "^7.1.0",
+        "@fortawesome/free-solid-svg-icons": "^7.1.0",
         "@rbardini/html": "^1.0.0",
         "feather-icons": "^4.28.0",
         "micromark": "^2.11.0",
@@ -671,6 +675,63 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.1.0.tgz",
+      "integrity": "sha512-l/BQM7fYntsCI//du+6sEnHOP6a74UixFyOYUyz2DLMXKx+6DEhfR3F2NYGE45XH1JJuIamacb4IZs9S0ZOWLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.1.0.tgz",
+      "integrity": "sha512-fNxRUk1KhjSbnbuBxlWSnBLKLBNun52ZBTcs22H/xEEzM6Ap81ZFTQ4bZBxVQGQgVY0xugKGoRcCbaKjLQ3XZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.1.0.tgz",
+      "integrity": "sha512-9byUd9bgNfthsZAjBl6GxOu1VPHgBuRUP9juI7ZoM98h8xNPTCTagfwUFyYscdZq4Hr7gD1azMfM9s5tIWKZZA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.1.0.tgz",
+      "integrity": "sha512-0e2fdEyB4AR+e6kU4yxwA/MonnYcw/CsMEP9lH82ORFi9svA6/RhDyhxIv5mlJaldmaHLLYVTb+3iEr+PDSZuQ==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.1.0.tgz",
+      "integrity": "sha512-Udu3K7SzAo9N013qt7qmm22/wo2hADdheXtBfxFTecp+ogsc0caQNRKEb7pkvvagUGOpG9wJC1ViH6WXs8oXIA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@html-validate/stylish": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
     "type-check": "tsc"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^7.1.0",
+    "@fortawesome/free-brands-svg-icons": "^7.1.0",
+    "@fortawesome/free-regular-svg-icons": "^7.1.0",
+    "@fortawesome/free-solid-svg-icons": "^7.1.0",
     "@rbardini/html": "^1.0.0",
     "feather-icons": "^4.28.0",
     "micromark": "^2.11.0",


### PR DESCRIPTION
Added optional support for using Font Awesome icons instead of Feather.

Default continues to be Feather icons, FA can be set using .meta.themeOptions.icons field in resume file.