### PR TITLE
Added support for certificate badges and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,9 @@ Here's an example using the default theme colors:
   }
 }
 ```
+
+### Certificate badges and notes
+
+If a [certificate](https://docs.jsonresume.org/schema#certificates) entry contains an `image` field, it is used as the URL of an image to display next to the entry as a badge for the certificate.
+
+If a certificate entry contains only `name` and optionally `url` but no `issuer` or `date`, it is considered as a "note" entry and rendered at the top of the list in a different format (for example to link to a full list).

--- a/components/certificates.js
+++ b/components/certificates.js
@@ -7,20 +7,45 @@ import Link from './link.js'
  * @returns {string | false}
  */
 export default function Certificates(certificates = []) {
+  const isNote = c =>
+    // “Note” entries: a URL + name, but no issuer/date/image
+    c && c.name && !c.issuer && !c.date && !c.image
+
+  const notes = certificates.filter(isNote)
+  const certs = certificates.filter(c => !isNote(c))
+
   return (
-    certificates.length > 0 &&
+    (notes.length > 0 || certs.length > 0) &&
     html`
       <section id="certificates">
         <h3>Certificates</h3>
         <div class="stack">
-          ${certificates.map(
-            ({ date, issuer, name, url }) => html`
+          ${notes.length > 0 &&
+          html` ${notes.map(({ name, url }) => html`<div class="meta">${Link(url, name)}</div>`)} `}
+          ${certs.map(
+            ({ date, issuer, name, url, image }) => html`
               <article>
                 <header>
-                  <h4>${Link(url, name)}</h4>
-                  <div class="meta">
-                    ${issuer && html`<div>Issued by <strong>${issuer}</strong></div>`} ${date && DateTime(date)}
-                  </div>
+                  <div style="display: flex; gap: 1rem; align-items: center;">
+                    ${
+                      image &&
+                      html`
+                        <a href="${url}" aria-label="${name}">
+                          <img
+                            src="${image}"
+                            alt=""
+                            loading="lazy"
+                            style="width: 56px; height: 56px; object-fit: contain;"
+                          />
+                        </a>
+                      `
+                    }
+                    <div style="min-width: 0;">
+                      <h4>${Link(url, name)}</h4>
+                      <div class="meta">
+                        ${issuer && html`<div>Issued by <strong>${issuer}</strong></div>`} ${date && DateTime(date)}
+                      </div>
+                    </div>
                 </header>
               </article>
             `,


### PR DESCRIPTION
If a  [certificate](https://docs.jsonresume.org/schema#certificates) entry contains an `image` field, it is used as the URL of an image to display next to the entry as a badge for the certificate.

If a certificate entry contains only `name` and optionally `url` but no `issuer` or `date`, it is considered as a "note" entry and rendered at the top of the list in a different format (for example to link to a full list).