### PR TITLE
Allow grouping project entries by type

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ Here's an example using the default theme colors:
   }
 }
 ```
+
+### Grouping projects by type
+
+If the `.meta.themeOptions.projectsByType` is `true`, project entries are rendered as separate sections according to their `type` field, instead of as a single section.

--- a/components/projects.js
+++ b/components/projects.js
@@ -11,58 +11,88 @@ const formatRoles = roles => (Intl.ListFormat ? new Intl.ListFormat('en').format
 
 /**
  * @param {import('../schema.d.ts').ResumeSchema['projects']} projects
+ * @param {{ groupByType?: boolean }} [options]
  * @returns {string | false}
  */
-export default function Projects(projects = []) {
-  return (
-    projects.length > 0 &&
-    html`
+export default function Projects(projects = [], { groupByType = false } = {}) {
+  if (projects.length === 0) return false
+
+  const renderProjects = list => html`
+    <div class="stack">
+      ${list.map(
+        ({
+          description,
+          entity,
+          highlights = [],
+          keywords = [],
+          name,
+          startDate,
+          endDate,
+          roles = [],
+          type,
+          url,
+        }) => html`
+          <article>
+            <header>
+              <h4>${Link(url, name)}</h4>
+              <div class="meta">
+                <div>
+                  ${roles.length > 0 && html`<strong>${formatRoles(roles)}</strong>`}
+                  ${entity && html`at <strong>${entity}</strong>`}
+                </div>
+                ${startDate && html`<div>${DateTimeDuration(startDate, endDate)}</div>`}
+                ${type && html`<div>${type}</div>`}
+              </div>
+            </header>
+            ${description && markdown(description)}
+            ${highlights.length > 0 &&
+            html`
+              <ul>
+                ${highlights.map(highlight => html`<li>${markdown(highlight)}</li>`)}
+              </ul>
+            `}
+            ${keywords.length > 0 &&
+            html`
+              <ul class="tag-list">
+                ${keywords.map(keyword => html`<li>${keyword}</li>`)}
+              </ul>
+            `}
+          </article>
+        `,
+      )}
+    </div>
+  `
+
+  if (!groupByType) {
+    return html`
       <section id="projects">
         <h3>Projects</h3>
-        <div class="stack">
-          ${projects.map(
-            ({
-              description,
-              entity,
-              highlights = [],
-              keywords = [],
-              name,
-              startDate,
-              endDate,
-              roles = [],
-              type,
-              url,
-            }) => html`
-              <article>
-                <header>
-                  <h4>${Link(url, name)}</h4>
-                  <div class="meta">
-                    <div>
-                      ${roles.length > 0 && html`<strong>${formatRoles(roles)}</strong>`}
-                      ${entity && html`at <strong>${entity}</strong>`}
-                    </div>
-                    ${startDate && html`<div>${DateTimeDuration(startDate, endDate)}</div>`}
-                    ${type && html`<div>${type}</div>`}
-                  </div>
-                </header>
-                ${description && markdown(description)}
-                ${highlights.length > 0 &&
-                html`
-                  <ul>
-                    ${highlights.map(highlight => html`<li>${markdown(highlight)}</li>`)}
-                  </ul>
-                `}
-                ${keywords.length > 0 &&
-                html`
-                  <ul class="tag-list">
-                    ${keywords.map(keyword => html`<li>${keyword}</li>`)}
-                  </ul>
-                `}
-              </article>
-            `,
-          )}
-        </div>
+        ${renderProjects(projects)}
       </section>
     `
-  )
+  }
+
+  const groups = projects.reduce((acc, project) => {
+    const type = project.type?.trim() || 'Projects'
+    acc[type] = acc[type] || []
+    acc[type].push(project)
+    return acc
+  }, /** @type {Record<string, NonNullable<import('../schema.d.ts').ResumeSchema['projects']>[number][]>} */ ({}))
+
+  const slugify = type =>
+    type
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '') || 'projects'
+
+  return html`
+    ${Object.entries(groups).map(
+      ([type, items]) => html`
+        <section id="${slugify(type) === 'projects' ? 'projects' : `projects-${slugify(type)}`}">
+          <h3>${type}</h3>
+          ${renderProjects(items)}
+        </section>
+      `,
+    )}
+  `
 }

--- a/components/projects.js
+++ b/components/projects.js
@@ -41,7 +41,7 @@ export default function Projects(projects = [], { groupByType = false } = {}) {
                   ${entity && html`at <strong>${entity}</strong>`}
                 </div>
                 ${startDate && html`<div>${DateTimeDuration(startDate, endDate)}</div>`}
-                ${type && html`<div>${type}</div>`}
+                ${type && !groupByType && html`<div>${type}</div>`}
               </div>
             </header>
             ${description && markdown(description)}

--- a/components/projects.js
+++ b/components/projects.js
@@ -38,7 +38,8 @@ export default function Projects(projects = [], { groupByType = false } = {}) {
               <div class="meta">
                 <div>
                   ${roles.length > 0 && html`<strong>${formatRoles(roles)}</strong>`}
-                  ${entity && html`at <strong>${entity}</strong>`}
+                  ${roles.length > 0 && entity && html`at `}
+                  ${entity && html`<strong>${markdown(entity).replace(/^<p>|<\/p>$/g, '')}</strong>`}
                 </div>
                 ${startDate && html`<div>${DateTimeDuration(startDate, endDate)}</div>`}
                 ${type && !groupByType && html`<div>${type}</div>`}

--- a/components/resume.js
+++ b/components/resume.js
@@ -22,6 +22,7 @@ import Work from './work.js'
  * @returns
  */
 export default function Resume(resume, { css, js } = {}) {
+  const projectsByType = Boolean(resume.meta?.themeOptions?.projectsByType)
   return html`<!doctype html>
     <html lang="en" style="${colors(resume.meta)}">
       <head>
@@ -40,9 +41,9 @@ export default function Resume(resume, { css, js } = {}) {
       </head>
       <body>
         ${Header(resume.basics)} ${Work(resume.work)} ${Volunteer(resume.volunteer)} ${Education(resume.education)}
-        ${Projects(resume.projects)} ${Awards(resume.awards)} ${Certificates(resume.certificates)}
-        ${Publications(resume.publications)} ${Skills(resume.skills)} ${Languages(resume.languages)}
-        ${Interests(resume.interests)} ${References(resume.references)}
+        ${Projects(resume.projects, { groupByType: projectsByType })} ${Awards(resume.awards)}
+        ${Certificates(resume.certificates)} ${Publications(resume.publications)} ${Skills(resume.skills)}
+        ${Languages(resume.languages)} ${Interests(resume.interests)} ${References(resume.references)}
       </body>
     </html>`
 }


### PR DESCRIPTION
This behavior is controlled by the new `.meta.themeOptions.projectsByType` option. If true, the "Projects" section is instead rendered as multiple sections, one for each different value of the "type" field.