### PR TITLE
Support for Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,19 @@ Here's an example using the default theme colors:
   }
 }
 ```
+
+### Table of contents
+
+You can enable a floating table of contents on the right side of the screen by setting `.meta.themeOptions.showTableOfContents` to `true`:
+
+```json
+{
+  "meta": {
+    "themeOptions": {
+      "showTableOfContents": true
+    }
+  }
+}
+```
+
+The table of contents automatically includes links to all resume sections that have content, plus a "Top" link to return to the beginning of the document. The active section is highlighted as you scroll through the resume. The table of contents is automatically hidden on smaller screens and in print mode.

--- a/assets/page.css
+++ b/assets/page.css
@@ -280,6 +280,11 @@ blockquote > * + *,
     display: contents;
   }
 
+  /* Ensure sections remain scrollable targets despite display: contents */
+  section > h3 {
+    scroll-margin-top: 2em;
+  }
+
   .icon-list {
     flex-direction: column;
   }
@@ -296,5 +301,70 @@ time + time-duration::before {
 @media print {
   time-duration {
     display: none;
+  }
+}
+
+/* Table of Contents */
+.table-of-contents {
+  position: fixed;
+  top: 2em;
+  right: 2em;
+  max-width: 12em;
+  padding: 1em;
+  background: var(--color-dimmed);
+  border-radius: 0.5em;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  z-index: 100;
+  max-height: calc(100vh - 4em);
+  overflow-y: auto;
+}
+
+.table-of-contents ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.table-of-contents li {
+  margin: 0;
+}
+
+.table-of-contents li + li {
+  margin-top: 0.5em;
+}
+
+.table-of-contents a {
+  display: block;
+  color: var(--color-secondary);
+  text-decoration: none;
+  padding: 0.3em 0.5em;
+  border-radius: 0.25em;
+  font-size: 0.9em;
+  transition: all 0.2s ease;
+}
+
+.table-of-contents a:hover {
+  color: var(--color-accent);
+  background: var(--color-background);
+  text-decoration: none;
+}
+
+.table-of-contents a.active {
+  color: var(--color-accent);
+  background: var(--color-background);
+  font-weight: bold;
+}
+
+/* Hide TOC on smaller screens and in print */
+@media print, (max-width: 64em) {
+  .table-of-contents {
+    display: none;
+  }
+}
+
+/* Adjust body padding when TOC is visible */
+@media (min-width: 64em) {
+  body:has(.table-of-contents) {
+    padding-right: 16em;
   }
 }

--- a/assets/page.js
+++ b/assets/page.js
@@ -28,3 +28,84 @@ class TimeDuration extends HTMLElement {
 }
 
 customElements.define('time-duration', TimeDuration)
+
+// Table of Contents active state tracking
+;(() => {
+  const toc = document.querySelector('.table-of-contents')
+  if (!toc) return
+
+  const links = toc.querySelectorAll('a[data-toc-target]')
+  if (!links.length) return
+
+  // Track all sections
+  const sections = Array.from(links)
+    .map(link => {
+      const target = link.getAttribute('data-toc-target')
+      if (target === 'top') return { element: document.body, link, id: target }
+      const section = document.getElementById(target)
+      if (!section) return null
+      // Use the h3 header as the scroll target (sections have display:contents)
+      const header = section.querySelector('h3')
+      return { element: section, scrollTarget: header || section, link, id: target }
+    })
+    .filter(Boolean)
+
+  if (!sections.length) return
+
+  // Update active link
+  const setActiveLink = target => {
+    links.forEach(link => link.classList.remove('active'))
+    const activeLink = sections.find(s => s.element === target)?.link
+    if (activeLink) activeLink.classList.add('active')
+  }
+
+  // Intersection Observer to track visible sections
+  // Since sections have display:contents, we observe the h3 headers or body
+  const observerOptions = {
+    root: null,
+    rootMargin: '-20% 0px -70% 0px', // Consider section "active" when it's in the top 30% of viewport
+    threshold: 0,
+  }
+
+  let activeSection = null
+
+  const observer = new IntersectionObserver(entries => {
+    // Find the topmost intersecting section
+    const intersecting = entries
+      .filter(entry => entry.isIntersecting)
+      .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+
+    if (intersecting.length > 0) {
+      // Get the section element from the observed target
+      const target = intersecting[0].target
+      const sectionData = sections.find(s => s.scrollTarget === target || s.element === target)
+      if (sectionData) {
+        activeSection = sectionData.element
+        setActiveLink(activeSection)
+      }
+    }
+  }, observerOptions)
+
+  // Observe scroll targets (h3 headers or body for "top")
+  sections.forEach(({ element, scrollTarget }) => {
+    observer.observe(scrollTarget || element)
+  })
+
+  // Handle smooth scrolling
+  links.forEach(link => {
+    link.addEventListener('click', e => {
+      e.preventDefault()
+      const target = link.getAttribute('data-toc-target')
+      const sectionData = sections.find(s => s.id === target)
+      if (sectionData) {
+        const scrollTarget = sectionData.scrollTarget || sectionData.element
+        scrollTarget.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        // Update active state immediately
+        setActiveLink(sectionData.element)
+      }
+    })
+  })
+
+  // Set initial active state
+  setActiveLink(sections[0].element)
+})()

--- a/components/resume.js
+++ b/components/resume.js
@@ -11,6 +11,7 @@ import Projects from './projects.js'
 import Publications from './publications.js'
 import References from './references.js'
 import Skills from './skills.js'
+import TableOfContents from './table-of-contents.js'
 import Volunteer from './volunteer.js'
 import Work from './work.js'
 
@@ -22,6 +23,7 @@ import Work from './work.js'
  * @returns
  */
 export default function Resume(resume, { css, js } = {}) {
+  const showTableOfContents = Boolean(resume.meta?.themeOptions?.showTableOfContents)
   return html`<!doctype html>
     <html lang="en" style="${colors(resume.meta)}">
       <head>
@@ -38,11 +40,12 @@ export default function Resume(resume, { css, js } = {}) {
           ${js}
         </script>`}
       </head>
-      <body>
-        ${Header(resume.basics)} ${Work(resume.work)} ${Volunteer(resume.volunteer)} ${Education(resume.education)}
-        ${Projects(resume.projects)} ${Awards(resume.awards)} ${Certificates(resume.certificates)}
-        ${Publications(resume.publications)} ${Skills(resume.skills)} ${Languages(resume.languages)}
-        ${Interests(resume.interests)} ${References(resume.references)}
+      <body id="top">
+        ${showTableOfContents && TableOfContents(resume)} ${Header(resume.basics)} ${Work(resume.work)}
+        ${Volunteer(resume.volunteer)} ${Education(resume.education)} ${Projects(resume.projects)}
+        ${Awards(resume.awards)} ${Certificates(resume.certificates)} ${Publications(resume.publications)}
+        ${Skills(resume.skills)} ${Languages(resume.languages)} ${Interests(resume.interests)}
+        ${References(resume.references)}
       </body>
     </html>`
 }

--- a/components/table-of-contents.js
+++ b/components/table-of-contents.js
@@ -1,0 +1,72 @@
+import { html } from '@rbardini/html'
+
+/**
+ * Slugifies a string for use in IDs
+ * @param {string} str
+ * @returns {string}
+ */
+const slugify = str =>
+  str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '') || str
+
+/**
+ * Generates section info for table of contents
+ * @param {string} id - Section ID
+ * @param {string} label - Section display label
+ * @param {boolean} hasContent - Whether section has content
+ * @returns {{ id: string, label: string } | null}
+ */
+const section = (id, label, hasContent) => (hasContent ? { id, label } : null)
+
+/**
+ * @param {import('../schema.d.ts').ResumeSchema} resume
+ * @param {{ groupByType?: boolean }} [options]
+ * @returns {string | false}
+ */
+export default function TableOfContents(resume) {
+  const {
+    basics,
+    work,
+    volunteer,
+    education,
+    projects,
+    awards,
+    certificates,
+    publications,
+    skills,
+    languages,
+    interests,
+    references,
+  } = resume
+
+  // Build list of sections that have content
+  const sections = [
+    section('work', 'Work', work && work.length > 0),
+    section('volunteer', 'Volunteer', volunteer && volunteer.length > 0),
+    section('education', 'Education', education && education.length > 0),
+    section('projects', 'Projects', projects && projects.length > 0),
+    section('awards', 'Awards', awards && awards.length > 0),
+    section('certificates', 'Certificates', certificates && certificates.length > 0),
+    section('publications', 'Publications', publications && publications.length > 0),
+    section('skills', 'Skills', skills && skills.length > 0),
+    section('languages', 'Languages', languages && languages.length > 0),
+    section('interests', 'Interests', interests && interests.length > 0),
+    section('references', 'References', references && references.length > 0),
+  ].filter(Boolean)
+
+  return (
+    sections.length > 0 &&
+    html`
+      <nav class="table-of-contents" aria-label="Table of contents">
+        <ul>
+          <li>
+            <a href="#top" data-toc-target="top"><b>${basics.name}</b></a>
+          </li>
+          ${sections.map(({ id, label }) => html`<li><a href="#${id}" data-toc-target="${id}">${label}</a></li>`)}
+        </ul>
+      </nav>
+    `
+  )
+}


### PR DESCRIPTION
You can enable a floating table of contents on the right side of the screen by setting `.meta.themeOptions.showTableOfContents` to `true`:

    {
      "meta": {
        "themeOptions": {
          "showTableOfContents": true
        }
      }
    }

The table of contents automatically includes links to all resume sections that have content, plus a "Top" link to return to the beginning of the document. The active section is highlighted as you scroll through the resume. The table of contents is automatically hidden on smaller screens and in print mode.